### PR TITLE
Bump version of CAP dependency

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -16,6 +16,8 @@ Version := Maximum( [
                    "2019.02.01", ## Tom's version
                    ## this line prevents merge conflicts
                    "2019.01.29", ## Mario's version
+                   ## this line prevents merge conflicts
+                   "2019.03.03", ## Fabian's version
                    ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -106,7 +108,7 @@ Dependencies := rec(
   GAP := ">= 4.9.1",
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
-                   [ "CAP", ">= 2019.01.29" ],
+                   [ "CAP", ">= 2019.03.02" ],
                    ],
   SuggestedOtherPackages := [
                    [ "MonoidalCategories", ">= 2019.01.20" ],


### PR DESCRIPTION
Toposes depends on https://github.com/homalg-project/CAP_project/commit/4509d461ee64b8fb487811280d1783a062cd4eae but https://github.com/homalg-project/CAP_project/commit/74cd2c95b3d29f82f482104896ef9960c0dfa1f2 already bumped the version