### PR TITLE
Fix cocartesian bugs transferred from MonoidalCategories

### DIFF
--- a/gap/CocartesianCoclosedCategories.gi
+++ b/gap/CocartesianCoclosedCategories.gi
@@ -188,9 +188,9 @@ end );
 ##
 CAP_INTERNAL_COCARTESIAN_COCLOSED_CATEGORIES_BASIC_OPERATIONS.MorphismFromCoexponentialToCoproduct :=
   [ [ "MorphismFromCoexponentialToCoproductWithGivenObjects", 1 ],
-    [ "DualOnObjects", 1 ],
+    [ "CocartesianDualOnObjects", 1 ],
     [ "Coproduct", 1 ],
-    [ "InternalHomOnObjects", 1 ] ];
+    [ "CoexponentialOnObjects", 1 ] ];
 ##
 InstallMethod( MorphismFromCoexponentialToCoproduct,
                [ IsCapCategoryObject, IsCapCategoryObject ],

--- a/gap/SymmetricCocartesianCoclosedCategoriesDerivedMethods.gi
+++ b/gap/SymmetricCocartesianCoclosedCategoriesDerivedMethods.gi
@@ -9,10 +9,6 @@ AddDerivationToCAP( CoproductToCoexponentialAdjunctionMap,
     coclosed_coevaluation := CocartesianCoevaluationMorphism( object_1, object_2 );
     
     return PreCompose( internal_cohom_on_morphisms, coclosed_coevaluation );
-    
-    return PreCompose( 
-             CoexponentialOnMorphisms( morphism, IdentityMorphism( object_1 ) ),
-             CocartesianCoevaluationMorphism( object_1, object_2 ) );
              
 end : CategoryFilter := IsCocartesianCoclosedCategory,
       Description := "CoproductToCoexponentialAdjunctionMap using CocartesianCoevaluationMorphism and Coexponential" );
@@ -110,8 +106,6 @@ AddDerivationToCAP( CocartesianDualOnMorphismsWithGivenCocartesianDuals,
     local category, result_morphism;
     
     category := CapCategory( morphism );
-    
-    result_morphism := CoexponentialOnMorphisms( IdentityMorphism( InitialObject( category ) ), morphism );
     
     result_morphism := PreCompose( [
                          IsomorphismFromCocartesianDualToCoexponential( Range( morphism ) ),
@@ -593,4 +587,4 @@ AddDerivationToCAP( CocartesianPostCoComposeMorphismWithGivenObjects,
              morphism );
     
 end : CategoryFilter := IsCocartesianCoclosedCategory and IsStrictCocartesianCategory,
-      Description := "CocartesianPostCoComposeMorphismWithGivenObjects using coclosed evluation, and cohom tensor adjunction" );
+      Description := "CocartesianPostCoComposeMorphismWithGivenObjects using coclosed evaluation, and cohom tensor adjunction" );


### PR DESCRIPTION
These are fixes from mistakes I made in the coclosed part of MonoidalCategories. Since Toposes is autogenerated from that, they transferred. I forgot to create a pull request back then.

The names of some variables (e.g. `internal_cohom_on_morphisms`) are not changed during the rewriting process. Overall, I guess this can hardly be fixed and is likely present at other places, so I left that untouched.