### PR TITLE
Bump version

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -17,7 +17,7 @@ Version := Maximum( [
                    ## this line prevents merge conflicts
                    "2019.01-29", ## Mario's version
                    ## this line prevents merge conflicts
-                   "2021.03-01", ## Fabian's version
+                   "2021.05-01", ## Fabian's version
                    ## this line prevents merge conflicts
                    "2019.09-17", ## Sepp's version
                    ] ),
@@ -124,7 +124,7 @@ Dependencies := rec(
   GAP := ">= 4.9.1",
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
-                   [ "CAP", ">= 2021.03-01" ],
+                   [ "CAP", ">= 2021.05-02" ],
                    ],
   SuggestedOtherPackages := [
                    [ "MonoidalCategories", ">= 2021.03-01" ],


### PR DESCRIPTION
Although no adjustments are necessary, make sure we use the CAP version from https://github.com/homalg-project/CAP_project/pull/665.