### PR TITLE
Test taking the opposite of a cartesian and cocartesian category

### DIFF
--- a/examples/OppositeCategory.g
+++ b/examples/OppositeCategory.g
@@ -1,0 +1,16 @@
+#! @Chapter Examples and Tests
+
+#! @Section Opposite category
+
+#! @Example
+
+LoadPackage( "Toposes", false );
+#! true
+LoadPackage( "FinSetsForCAP", false );
+#! true
+
+op := Opposite( SkeletalFinSets );;
+ListKnownCategoricalProperties( op );
+#! [ "IsCartesianCategory", "IsCocartesianCategory", "IsSkeletalCategory" ]
+
+#! @EndExample


### PR DESCRIPTION
The CI will fail due to the checks added in https://github.com/homalg-project/CAP_project/commit/435297562ef6477340c6656afd3cb35e06b04a50

Example:
```
Error, the dual operation of IsomorphismFromCartesianDualToExponential, i.e. IsomorphismFromCoexponentialToCocartesianDual, has the unexpected dual operation IsomorphismFromExponentialToCartesianDual
```

@mohamed-barakat `MonoidalCategories` does not show such errors, so I assume the problem is in the code generating `Toposes`.