### PR TITLE
re-added SubobjectOfClassifyingMorphism

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Toposes",
 Subtitle := "Elementary toposes",
-Version := "2022.04-24",
+Version := "2022.04-25",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/Topos.gd
+++ b/gap/Topos.gd
@@ -82,8 +82,8 @@ CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsElementaryTopos :=
           Concatenation( [
                   "SubobjectClassifier",
                   "ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier",
-                  #"TruthMorphismOfTrueWithGivenObjects", ## can be derived from SubobjectClassifier and ClassifyingMorphismOfSubobjectWithGivenSubobjectClassifier
-                  #"SubobjectOfClassifyingMorphism", ## can be derived from SubobjectClassifier and TruthMorphismOfTrueWithGivenObjects
+                  #"TruthMorphismOfTrueWithGivenObjects", ## derived from SubobjectClassifier & ClassifyingMorphismOfSubobjectWithGiven... & IdentityMorphism
+                  "SubobjectOfClassifyingMorphism", ## can be derived from SubobjectClassifier & TruthMorphismOfTrueWithGivenObjects & ProjectionInFactorOfFiberProduct
                   ],
                   CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsCartesianClosedCategory,
                   CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsFiniteCompleteCategory,


### PR DESCRIPTION
to CAP_INTERNAL_CONSTRUCTIVE_CATEGORIES_RECORD.IsElementaryTopos,
since its derivation depends on a possibly missing ProjectionInFactorOfFiberProduct