### PR TITLE
dual_preprocessor_func's for (Direct/Co)ProductOnMorphismsWithGiven*

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Toposes",
 Subtitle := "Elementary toposes",
-Version := "2022.04-25",
+Version := "2022.04-26",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
@@ -116,7 +116,7 @@ Dependencies := rec(
                    [ "CAP", ">= 2022.03-06" ],
                    ],
   SuggestedOtherPackages := [
-                   [ "MonoidalCategories", ">= 2022.04-01" ],
+                   [ "MonoidalCategories", ">= 2022.04-04" ],
                    [ "CategoryConstructor", ">= 2022.03-01" ],
                    ],
   ExternalConditions := [ ],

--- a/gap/CartesianCategoriesMethodRecord.gi
+++ b/gap/CartesianCategoriesMethodRecord.gi
@@ -24,6 +24,8 @@ DirectProductOnMorphismsWithGivenDirectProducts := rec(
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
   return_type := "morphism",
   dual_operation := "CoproductOnMorphismsWithGivenCoproducts",
+  dual_preprocessor_func :=
+    { cat, s, alpha, beta, r } -> [ Opposite( cat ), Opposite( r ), Opposite( alpha ), Opposite( beta ), Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 

--- a/gap/CocartesianCategoriesMethodRecord.gi
+++ b/gap/CocartesianCategoriesMethodRecord.gi
@@ -24,6 +24,8 @@ CoproductOnMorphismsWithGivenCoproducts := rec(
   io_type := [ [ "s", "alpha", "beta", "r" ], [ "s", "r" ] ],
   return_type := "morphism",
   dual_operation := "DirectProductOnMorphismsWithGivenDirectProducts",
+  dual_preprocessor_func :=
+    { cat, s, alpha, beta, r } -> [ Opposite( cat ), Opposite( r ), Opposite( alpha ), Opposite( beta ), Opposite( s ) ],
   dual_arguments_reversed := false,
 ),
 


### PR DESCRIPTION
Originates from [here](https://github.com/homalg-project/CAP_project/pull/887#issuecomment-1109636932).

Note that regenerating Toposes would not help, since the required method records are not translated to `Toposes`.