### PR TITLE
Do not load suggested dependencies automatically

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "Toposes",
 Subtitle := "Elementary toposes",
-Version := "2022.04-29",
+Version := "2022.05-01",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/tst/100_LoadPackage.tst
+++ b/tst/100_LoadPackage.tst
@@ -3,6 +3,8 @@
 #
 # This file tests if the package can be loaded without errors or warnings.
 #
+# do not load suggested dependencies automatically
+gap> PushOptions( rec( OnlyNeeded := true ) );
 gap> package_loading_info_level := InfoLevel( InfoPackageLoading );;
 gap> SetInfoLevel( InfoPackageLoading, PACKAGE_ERROR );;
 gap> LoadPackage( "Toposes", false );

--- a/tst/Opposite.tst
+++ b/tst/Opposite.tst
@@ -5,14 +5,14 @@
 gap> LoadPackage( "FinSetsForCAP", false );
 true
 gap> Length( ListInstalledOperationsOfCategory( SkeletalFinSets ) );
-264
+253
 gap> BooleanAlgebras := Opposite( SkeletalFinSets );
 Opposite of SkeletalFinSets
 gap> Length( ListInstalledOperationsOfCategory( BooleanAlgebras ) );
-240
+229
 gap> Opposite( BooleanAlgebras );
 SkeletalFinSets
 gap> FS := Opposite( WrapperCategory( BooleanAlgebras, rec( ) ) );
 Opposite of WrapperCategory( Opposite of SkeletalFinSets )
 gap> Length( ListInstalledOperationsOfCategory( FS ) );
-240
+229


### PR DESCRIPTION
This way, the tests are independent of `CategoryConstructor` being available.

This avoids unexpected issues like https://github.com/homalg-project/Toposes/pull/79#issuecomment-1103151990.